### PR TITLE
Eliminate unused variables

### DIFF
--- a/gcdbz.cpp
+++ b/gcdbz.cpp
@@ -110,7 +110,6 @@ char* GCdbz::compress(GReadBuf *readbuf, char* delim) {
   // (exactly as left after a previous call)
  if (zf==NULL || uncompress)
     GError("GCdbz Error: cannot use compress() method !\n");
- unsigned int total_out=0;
  int c=0;
  bool in_rec=true;
  int delimlen=strlen(delim);
@@ -165,7 +164,6 @@ char* GCdbz::compress(GReadBuf *readbuf, char* delim) {
         if (toWrite>0) {
              if (fwrite(lbuf, 1, toWrite, zf)<toWrite)
                 GError("Error writing deflate chunk!\n");
-             total_out+=toWrite;
              zrecsize+=toWrite;
              zpos+=toWrite;
              }

--- a/gclib/gcdb.h
+++ b/gclib/gcdb.h
@@ -256,8 +256,6 @@ class GCdbRead {
   //struct mcdb_mmap *map;
   char *map;         // ptr, mmap pointer
     uintptr_t size; // mmap size, initialized if map is nonzero
-    uint32_t b;   // hash table stride bits: (data < 4GB) ? 3 : 4
-    uint32_t n;   // num records in mcdb
 
   uint32 loop; // number of hash slots searched under this key
   uint32 hslots; // initialized if loop is nonzero
@@ -267,7 +265,6 @@ class GCdbRead {
   uintptr_t dpos; // initialized if cdb_findnext() returns 1
 
   uint32 dlen; // initialized if cdb_findnext() returns 1
-  uint32 klen; // initialized if cdb_findnext() returns 1
 
   uint32 khash; // initialized if loop is nonzero
 


### PR DESCRIPTION
Some patches to silence build warnings.
Some of these are in gclib, where appears to be a bundled copy of another repo, so the changes may need to be applied there as well.